### PR TITLE
build(helm-lint): fix trigger paths

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -5,11 +5,11 @@ on:
     branches:
       - '!main'
     paths:
-      - 'charts/*'
+      - 'chart/*'
   pull_request:
     branches: [main]
     paths:
-      - 'charts/*'
+      - 'chart/*'
 
 concurrency:
   group: helmlint-${{ github.ref }}


### PR DESCRIPTION
## Description

The helm lint workflow won't run due to no path matching `charts`. Path should be `chart`

## Related Issue

Fixes #
<!-- or -->
Relates to #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (security config, docs update, etc)

## Checklist before merging

- [ ] Test, docs, adr added or updated as needed
- [ ] [Contributor Guide Steps](https://github.com/justinthelaw/repository-template/blob/main/.github/CONTRIBUTING.md) followed
